### PR TITLE
feat: add `inAttr` parameter to `decodeHTML`

### DIFF
--- a/Sources/HTMLEntityCoder/decodeHTML.swift
+++ b/Sources/HTMLEntityCoder/decodeHTML.swift
@@ -1,14 +1,20 @@
 import DequeModule
 
 /// Decodes any HTML named and numerical character references.
-public func decodeHTML(_ input: String) -> String {
+///
+/// - Parameters:
+///   - input: The input text.
+///   - isInAttr: Specifies if character refernces are treated as if they are in attributes.
+///
+/// - Returns: The decoded text.
+public func decodeHTML(_ input: String, inAttr isInAttr: Bool = false) -> String {
     var output: ContiguousArray<Unicode.Scalar> = []
     output.reserveCapacity(input.unicodeScalars.count)
     var input = Deque(input.unicodeScalars)
     while let c = input.popFirst() {
         switch c {
         case "&":
-            var tokenizer = CharRefTokenizer(inAttr: false)
+            var tokenizer = CharRefTokenizer(inAttr: isInAttr)
             repeat {
                 switch tokenizer.step(input: &input) {
                 case .continue: continue


### PR DESCRIPTION
The `inAttr` parameter specifies if character references are treated as if they are in attributes. The parser behaves differently whether character references are in attributes or not.