### PR TITLE
build: drop Swift 6.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,23 +9,6 @@ defaults:
   run:
     shell: bash -euo pipefail {0}
 jobs:
-  build-swift-6-0:
-    runs-on: ubuntu-24.04-arm
-    container: swift:6.0
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: |
-            ~/.cache/org.swift.swiftpm
-            ~/.swiftpm
-            .build
-          key: ${{ runner.os }}-swiftpm-6.0-${{ hashFiles('Package.resolved') }}
-          restore-keys: ${{ runner.os }}-swiftpm-6.0-
-      - run: swift --version
-      - run: swift build
   test:
     runs-on: ubuntu-24.04-arm
     container: swift:6.2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 
 import PackageDescription
 


### PR DESCRIPTION
Swift Playground 4.7 includes Swift 6.2, so we no longer have to support Swift 6.0. This PR means that we also drop Swift Playground 4.6 support.