### PR TITLE
revert: build: bump github.com/apple/swift-collections from 1.3.0 to 1.4.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5c8cc14b7b85960fd9c3ef1a6e3536ade55e840b3e9aa5d54cfbc4a1c3182b26",
+  "originHash" : "d1784013065e7f0fed0af54280281bf4ca08e435dfa0a193baa6e14edd9efad5",
   "pins" : [
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
-        "version" : "1.4.0"
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     }
   ],


### PR DESCRIPTION
Reverts kkebo/html-entity-coder#21