### PR TITLE
build: limit swift-collections to versions below 1.4.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5c8cc14b7b85960fd9c3ef1a6e3536ade55e840b3e9aa5d54cfbc4a1c3182b26",
+  "originHash" : "0420cae995227ea867ad6762d63b0a6e63f6d9e53f066cbf7786893dd4e95cec",
   "pins" : [
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
-        "version" : "1.4.0"
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-collections", from: "1.3.0")
+        .package(url: "https://github.com/apple/swift-collections", "1.3.0"..<"1.4.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Swift Playground can't build swift-collections since swift-collections
1.4.0. That's because it has started using `package` keywords, which
requires the `-package-name` argument.