### PR TITLE
ci: use GitHub CLI to comment to PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3.0.1
-        with:
-          message: ${{ needs.test.outputs.SUMMARY }}
-          comment-tag: coverage
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SUMMARY: ${{ needs.test.outputs.SUMMARY }}
+        run: gh pr comment "$PR_NUMBER" --body "$SUMMARY"
   lint:
     runs-on: ubuntu-24.04-arm
     container: swift:6.2


### PR DESCRIPTION
thollander/actions-comment-pull-request is no longer maintained actively.