### PR TITLE
ci: group CodeQL actions in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
       - "kkebo"
     commit-message:
       prefix: "ci"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
It seems that PRs like #44 and #45 should be merged at the same time to pass CI checks.